### PR TITLE
Drop unused Levenshtein import

### DIFF
--- a/prediction/autocomplete.py
+++ b/prediction/autocomplete.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from Levenshtein import distance
 import heapq
 import math
 


### PR DESCRIPTION
I'm not sure what Levenshtein library you intended to use, but this function wasn't being called, so I just dropped it. If you need to use one in the future, perhaps install https://pypi.python.org/pypi/Distance/? I was able to get it with sudo pip install distance.
